### PR TITLE
Fix Azure brand ;)

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -1,32 +1,32 @@
 > **Disclaimer:**
-Service Fabric integration was added to Træfik in [version 1.5](https://github.com/containous/traefik/releases/tag/v1.5.0) - please use this version or later.
+Azure Service Fabric integration was added to Træfik in [version 1.5](https://github.com/containous/traefik/releases/tag/v1.5.0) - please use this version or later.
 
 > **Warning:**
 Work is currently underway in Træfik to standardize label names between providers. In future releases labels will change, for example: `traefik.expose` -> `traefik.enable`. See [PR16 to follow the work](https://github.com/containous/traefik-extra-service-fabric/pull/16).
 
-# Running Træfik on Service Fabric
+# Running Træfik on Azure Service Fabric
 
 ## What is Træfik?
 Træfik (pronounced like traffic) is a modern HTTP reverse proxy and load balancer made to deploy microservices with ease. It supports several backends (Docker, Swarm mode, Kubernetes, Marathon, Consul, Etcd, Rancher, Amazon ECS, and a lot more) to manage its configuration automatically and dynamically.
 For more information, visit the [Træfik homepage](https://traefik.io/)
 
-## What is Service Fabric?
+## What is Azure Service Fabric?
 Azure Service Fabric is a distributed systems platform that makes it easy to package, deploy, and manage scalable and reliable microservices and containers.
-For more information, visit the [Service Fabric homepage](https://azure.microsoft.com/en-gb/services/service-fabric/)
+For more information, visit the [Azure Service Fabric homepage](https://azure.microsoft.com/en-gb/services/service-fabric/)
 
-## Why run Træfik on Service Fabric?
-Integrating Træfik and Service Fabric allows you to configure much more advanced, yet flexible, ingress routing scenarios for your Service Fabric hosted services and applications. You get all the benefits of using Træfik to configure your routing whilst also getting the benefits of Service Fabric's packaging model.
+## Why run Træfik on Azure Service Fabric?
+Integrating Træfik and Azure Service Fabric allows you to configure much more advanced, yet flexible, ingress routing scenarios for your Service Fabric hosted services and applications. You get all the benefits of using Træfik to configure your routing whilst also getting the benefits of Service Fabric's packaging model.
 
-# Deploying Traefik to Service Fabric
-Service Fabric supports many different methods of deploying applications. Please select the most appropriate from the list below.
+# Deploying Traefik to Azure Service Fabric
+Azure Service Fabric supports many different methods of deploying applications. Please select the most appropriate from the list below.
 * [Windows using Visual Studio](Docs/Deployments/VisualStudio.MD)
 * [Windows, MacOS and Linux using sfctl](Docs/Deployments/sfctl.MD)
 * [Windows, MacOS and Linux using docker](Docs/Deployments/docker.MD) [Not recommended currently]
 
 # Releases
-The Service Fabric integration ships as part of Træfik v1.5 or greater, so for stable builds please use the official [Træfik releases page](https://github.com/containous/traefik/releases). The [releases](https://github.com/jjcollinge/traefik-on-service-fabric/releases) on this repository are for experimental features that may or may not be included in the upstream Træfik tree at a later date.
+The Azure Service Fabric integration ships as part of Træfik v1.5 or greater, so for stable builds please use the official [Træfik releases page](https://github.com/containous/traefik/releases). The [releases](https://github.com/jjcollinge/traefik-on-service-fabric/releases) on this repository are for experimental features that may or may not be included in the upstream Træfik tree at a later date.
 
-# Exposing a Service Fabric Application
+# Exposing a Azure Service Fabric Application
 Træfik uses the concept of **labels** to configure how services are exposed.
 
 > Labels allow you to define additional metadata for your services which Træfik can use to configure itself dynamically.
@@ -93,29 +93,29 @@ Once deployed, logs will be stored in the nodes Service Fabric folder. This will
 
 #### Common Issues
 
-- Service Fabric Provider not shown in Traefik Dashboard: Check you have correctly configured the certificates and clustermanagementurl
+- Azure Service Fabric Provider not shown in Traefik Dashboard: Check you have correctly configured the certificates and clustermanagementurl
 - No events showing in App Insights for Traefik: Check you have uncommented the default services section and double check your instrumentation key is correct
 
 ## Custom Templates
 > For advanced users only
 
-If the default configuration the Service Fabric Træfik provider builds is not sufficient for your needs, you can write a custom template that the provider will use instead. Documentation on how to write a custom template is available [here](https://docs.traefik.io/configuration/commons/#override-default-configuration-template). Your custom template will need to be added to either your application's `Code` or `Config` folders and the relative URL provided in the traefik.toml configuration.
+If the default configuration the Azure Service Fabric Træfik provider builds is not sufficient for your needs, you can write a custom template that the provider will use instead. Documentation on how to write a custom template is available [here](https://docs.traefik.io/configuration/commons/#override-default-configuration-template). Your custom template will need to be added to either your application's `Code` or `Config` folders and the relative URL provided in the traefik.toml configuration.
 The functions available for you to use in your custom template are documented [here](https://github.com/jjcollinge/traefik-on-service-fabric/blob/master/Docs/CustomTemplates.MD)
 
-## How does Træfik on Service Fabric work?
-Træfik is hosted as a Service Fabric Guest Executable. Træfik has a built-in Service Fabric [provider](https://github.com/containous/traefik/tree/master/provider) which will query the Service Fabric management API to discover what services are currently being hosted in the cluster (referred to as `backends`). The provider then maps routing rules (known as `frontends`) to these service instances (referred to as `backends`). Ingress flows in via `entrypoints` (http, https, etc.), `frontends` are then applied to [match](https://docs.traefik.io/basics/#matchers) and [modify](https://docs.traefik.io/basics/#modifiers) each requests before load balancing across the associated `backends`. The provider will take into account the `Health` and `Status` of each of the services to ensure requests are only routed to healthy service instances.
+## How does Træfik on Azure Service Fabric work?
+Træfik is hosted as a Azure Service Fabric Guest Executable. Træfik has a built-in Azure Service Fabric [provider](https://github.com/containous/traefik/tree/master/provider) which will query the Service Fabric management API to discover what services are currently being hosted in the cluster (referred to as `backends`). The provider then maps routing rules (known as `frontends`) to these service instances (referred to as `backends`). Ingress flows in via `entrypoints` (http, https, etc.), `frontends` are then applied to [match](https://docs.traefik.io/basics/#matchers) and [modify](https://docs.traefik.io/basics/#modifiers) each requests before load balancing across the associated `backends`. The provider will take into account the `Health` and `Status` of each of the services to ensure requests are only routed to healthy service instances.
 
 To learn more about how Træfik works and how you can configure is, please [see their documentation](https://docs.traefik.io/basics/).
 
 ## Updating Traefik
-If you would like to update the Træfik binary, certs or traefik.toml file. You can use Service Fabric's built in 'rolling updates' as you would with any other application package.
+If you would like to update the Træfik binary, certs or traefik.toml file. You can use Azure Service Fabric's built in 'rolling updates' as you would with any other application package.
 
 ## Contributing 
 
 See our [Contributing guide](Contributing.MD)
 
 ## Related Repositories
-- Traefik Service Fabric provider development: https://github.com/containous/traefik-extra-service-fabric
+- Traefik Azure Service Fabric provider development: https://github.com/containous/traefik-extra-service-fabric
 - Go SF Management SDK: https://github.com/jjcollinge/servicefabric
 - sfctl for property management: https://github.com/Azure/service-fabric-cli/pull/53
 - Application Insights Watchdog: https://github.com/lawrencegripper/traefik-appinsights-watchdog


### PR DESCRIPTION
Hi @jjcollinge 
It seems it would be a good idea to be compliant with Azure guidelines ^_^
I replaced `Service Fabric` by `Azure Service Fabric` in the README. The repository subtitle should be changed too.