### PR TITLE
Doc fix for issue #69 (Linux specific instructions)

### DIFF
--- a/Docs/Deployments/sfctl.MD
+++ b/Docs/Deployments/sfctl.MD
@@ -9,11 +9,11 @@ First things first, make sure you have a Service Fabric cluster up and running, 
     
     `git clone https://github.com/jjcollinge/traefik-on-service-fabric.git`
 
-2. Download the latest Træfik binary for your architecture from the [releases page](https://github.com/containous/traefik/releases)
+2. Download the latest Træfik binary for your architecture from the [releases page](https://github.com/containous/traefik/releases).
 
     `curl -LOk https://github.com/containous/traefik/releases/download/v1.5.4/traefik_windows-amd64.exe > traefik.exe`
 
-3. Copy the Træfik binary to the expected location
+3. Copy the Træfik binary to the expected location.
 
     `cp traefik.exe $REPO_ROOT\Traefik\ApplicationPackageRoot\TraefikPkg\Code\`
 
@@ -21,11 +21,11 @@ First things first, make sure you have a Service Fabric cluster up and running, 
 
 4. Træfik must authenticate to the Service Fabric management API. Currently, you can only do this using a PEM formatted client certificate. If you only have a `.pfx` certificate you will need to convert it using the following commands:
     
-    * Extract the private key from the `.pfx` file
+    * Extract the private key from the `.pfx` file.
 
         `openssl pkcs12 -in $pfxCertFilePath -nocerts -nodes -out "$clientCertOutputDir\servicefabric.key" -passin pass:$certPass`
 
-    * Extract the certificate from the `.pfx` file
+    * Extract the certificate from the `.pfx` file.
 
         `openssl pkcs12 -in $pfxCertFilePath -clcerts -nokeys -out "clientCertOutputDir\servicefabric.crt" -passin pass:$certPass`
     
@@ -37,101 +37,106 @@ First things first, make sure you have a Service Fabric cluster up and running, 
 
 6. Open `$REPO_ROOT\Traefik\Traefik\ApplicationPackageRoot\TraefikPkg\Code\traefik.toml` in a text editor. If you're using a secure cluster, ensure the TLS configuration section is uncommented and make sure the provided certificate paths are correct. Additionally, change the `clustermanagementurl` to use the prefix `https://`.
 
-> The `clustermanagementurl` setting is relative to where Træfik is running. If Træfik is running inside the cluster on every node, the `clustermanagementurl` should be left as `http[s]://localhost:19080`, if however, Træfik is running externally to the cluster, an accessible endpoint should be provided. If you are testing Træfik against an unsecure cluster, like your local onebox cluster, use `http://localhost:19080`
+    > The `clustermanagementurl` setting is relative to where Træfik is running. If Træfik is running inside    the cluster on every node, the `clustermanagementurl` should be left as `http[s]://localhost:19080`, if    however, Træfik is running externally to the cluster, an accessible endpoint should be provided. If you    are testing Træfik against an unsecure cluster, like your local onebox cluster, use    `http://localhost:19080`
 
-```toml
-################################################################
-# Service Fabric provider
-################################################################
+    ```toml
+    ################################################################
+    # Service Fabric provider
+    ################################################################
 
-# Enable Service Fabric configuration backend
-[servicefabric]
+    # Enable Service Fabric configuration backend
+    [servicefabric] 
 
-# Service Fabric Management Endpoint
-clustermanagementurl = "https://localhost:19080"
+    # Service Fabric Management Endpoint
+    clustermanagementurl = "https://localhost:19080"
 
-# Service Fabric Management Endpoint API Version
-apiversion = "3.0"
+        # Service Fabric Management Endpoint API Version        
+        apiversion = "3.0"
 
-# Enable TLS connection.
-#
-# Optional
-#
- [serviceFabric.tls]
-   cert = "certs/servicefabric.crt"
-   key = "certs/servicefabric.key"
-   insecureskipverify = true
-```
+        # Enable TLS connection.
+        #
+        # Optional
+        #
+    [serviceFabric.tls]
+      cert = "certs/servicefabric.crt"
+      key = "certs/servicefabric.key"
+      insecureskipverify = true
+    ```
 
-> **NOTE:** If you are deploying to a Service Fabric Linux cluster, you have to update `traefik.toml`, `ApplicationManifest.xml`, and `ServiceManifest.xml` as shown below: 
->
->***traefik.toml***
->
->Update Traefik's HTTP endpoint to a high port (e.g. 8081)
->
->```
->[entryPoints]
->[entryPoints.http]
->address = ":8081"
->```
->
->***AplicationManifest.xml***
->
->Delete or comment out the `RunAsPolicy`
->```
->    <!--<Policies>
->      <RunAsPolicy CodePackageRef="Code" UserRef="AdminUser" EntryPointType="All" />
->    </Policies>-->
->```
->You can also delete or comment out the `Principals` section, as it is no longer required.
->
->
->***ServiceManifest.xml***
->
->Update Træfik's proxy endpoint to use the previouly configured high port:
->
->```
-><Endpoint Name="TraefikTypeEndpoint" UriScheme="http" Port="8081" />
->```
->Finally, remove the `.exe` file extension from the program name.   
->
->```
->    <EntryPoint>
->      <ExeHost>
->        <Program>traefik</Program>
->        ...
->      </ExeHost>
->    </EntryPoint>
->```
+7. *Applies to Linux clusters only. If you deploy on a Windows cluster, proceed with step 8* 
 
-7. *Optional*  You can choose to enable a watchdog service which will report stats and check Træfik is routing correctly by sending synthetic requests and recording the results. The results of these checks are sent to Application Insights. If you would like this enabled follow [the guide here before continuing](../EnableWatchdog.MD).
+    If you are deploying Træfik on a Service Fabric **Linux** cluster, you update `traefik.toml`, `ApplicationManifest.xml`, and `ServiceManifest.xml` as shown below. 
 
-8. Now we need to connect `sfctl` to our cluster using a suitable authentication method
+    ***traefik.toml***
+
+    Update Traefik's HTTP endpoint to use a high port (e.g. 8081).
+
+    ```
+    [entryPoints]
+    [entryPoints.http]
+    address = ":8081"
+    ```
+
+    ***AplicationManifest.xml***
+
+    Delete or comment out the `RunAsPolicy`.
+    ```
+        <!--<Policies>
+          <RunAsPolicy CodePackageRef="Code" UserRef="AdminUser" EntryPointType="All" />
+        </Policies>-->
+    ```
+    You can also delete or comment out the `Principals` section, as it is no longer required.
+
+    ***ServiceManifest.xml***
+
+    Update Træfik's proxy endpoint to use the previouly configured high port:
+
+    ```
+    <Endpoint Name="TraefikTypeEndpoint" UriScheme="http" Port="8081" />
+    ```
+    Finally, remove the `.exe` file extension from the program name.   
+
+    ```
+        <EntryPoint>
+            <ExeHost>
+                <Program>traefik</Program>
+                ...
+            </ExeHost>
+        </EntryPoint>
+    ```
+
+8. *This step is optional*  
+
+    You can choose to enable a watchdog service which will report stats and check Træfik is routing correctly by sending synthetic requests and recording the results. The results of these checks are sent to Application Insights. If you would like this enabled follow [the guide here before continuing](../EnableWatchdog.MD).
+
+9. Now we need to connect `sfctl` to our cluster using a suitable authentication method.
 
     `sfctl cluster select --endpoint https://FQDN:19080 --pem /path/to/my/pem/cert.pem --no-verify`
 
-9. We next need to upload our application package to the cluster
+10. We next need to upload our application package to the cluster.
 
     `sfctl application upload --path $REPO_ROOT\Traefik\ApplicationPackageRoot --show-progress`
 
-10. Now provision a type from the uploaded package
+11. Now provision a type from the uploaded package.
 
     `sfctl application provision --application-type-build-path $REPO_ROOT\Traefik\ApplicationPackageRoot`
 
-11. Finally create a named instance of that package
+12. Finally create a named instance of that package.
 
     `sfctl application create --app-name fabric:/Traefik --app-type TraefikType --app-version 1.0.4`
 
-12. To be able to ingress external requests via Træfik you'll need to open up and map the relevant ports on your public load balancer. For clusters on Azure, this will be your Azure Load Balancer. The default ports are; `tcp/80` (proxy) and `tcp/8080` (API) but these can be configured in `$REPO_ROOT\Traefik\ApplicationPackageRoot\TraefikPkg\Code\traefik.toml` and in `$REPO_ROOT\Traefik\Traefik\ApplicationPackageRoot\TraefikPkg\ServiceManifest.xml`.
+13. To be able to ingress external requests via Træfik you'll need to open up and map the relevant ports on your public load balancer. For clusters on Azure, this will be your Azure Load Balancer. The default ports are; `tcp/80` (proxy) and `tcp/8080` (API) but these can be configured in `$REPO_ROOT\Traefik\ApplicationPackageRoot\TraefikPkg\Code\traefik.toml` and in `$REPO_ROOT\Traefik\Traefik\ApplicationPackageRoot\TraefikPkg\ServiceManifest.xml`. 
 
->**NOTE:** If you have applied the changes for Linux clusters in step 6, you can map Traefik's proxy
->endpoint using a high port to a standard port (e.g. 80 or 443) on the Azure Load Balancer.
+    If you have applied the changes for Linux clusters in step 7, you can map Traefik's proxy
+endpoint using a high port to a standard port (e.g. 80 or 443) on the Azure Load Balancer.
 
 13. Once the load balancer has been configured to route traffic on the required ports, you should be able to visit the Træfik dashboard at http[s]://[clusterfqdn]:8080 if you have it enabled.
 
     ![img](../Images/traefikonsf.png)
 
-> If your cluster does not have any applications deployed, you will see an empty dashboard. **NOTE:** The dashboard will not render in various versions of Internet Explorer.
+    > If your cluster does not have any applications deployed, you will see an empty dashboard. 
+    
+    >**NOTE:** The dashboard will not render in various versions of Internet Explorer.
 
 
 

--- a/Docs/Deployments/sfctl.MD
+++ b/Docs/Deployments/sfctl.MD
@@ -83,7 +83,7 @@ apiversion = "3.0"
 >      <RunAsPolicy CodePackageRef="Code" UserRef="AdminUser" EntryPointType="All" />
 >    </Policies>-->
 >```
->You can also delete or comment out the `Principals` section, as it no longer required.
+>You can also delete or comment out the `Principals` section, as it is no longer required.
 >
 >
 >***ServiceManifest.xml***

--- a/Docs/Deployments/sfctl.MD
+++ b/Docs/Deployments/sfctl.MD
@@ -63,18 +63,48 @@ apiversion = "3.0"
    insecureskipverify = true
 ```
 
+> **NOTE:** If you are deploying to a Service Fabric Linux cluster, you have to update `traefik.toml`, `ApplicationManifest.xml`, and `ServiceManifest.xml` as shown below: 
+>
+>***traefik.toml***
+>
+>Update Traefik's HTTP endpoint to a high port (e.g. 8081)
+>
+>```
+>[entryPoints]
+>[entryPoints.http]
+>address = ":8081"
+>```
+>
+>***AplicationManifest.xml***
+>
+>Delete or comment out the `RunAsPolicy`
+>```
+>    <!--<Policies>
+>      <RunAsPolicy CodePackageRef="Code" UserRef="AdminUser" EntryPointType="All" />
+>    </Policies>-->
+>```
+>You can also delete or comment out the `Principals` section, as it no longer required.
+>
+>
+>***ServiceManifest.xml***
+>
+>Update Træfik's proxy endpoint to use the previouly configured high port:
+>
+>```
+><Endpoint Name="TraefikTypeEndpoint" UriScheme="http" Port="8081" />
+>```
+>Finally, remove the `.exe` file extension from the program name.   
+>
+>```
+>    <EntryPoint>
+>      <ExeHost>
+>        <Program>traefik</Program>
+>        ...
+>      </ExeHost>
+>    </EntryPoint>
+>```
+
 7. *Optional*  You can choose to enable a watchdog service which will report stats and check Træfik is routing correctly by sending synthetic requests and recording the results. The results of these checks are sent to Application Insights. If you would like this enabled follow [the guide here before continuing](../EnableWatchdog.MD).
-
-> **NOTE:** If you are running on Linux/Mac you have to change the ServiceManifest.xml as below: 
-
-```
-   <EntryPoint>
-      <ExeHost>
-        <Program>traefik</Program>
-        ...
-      </ExeHost>
-    </EntryPoint>
-```
 
 8. Now we need to connect `sfctl` to our cluster using a suitable authentication method
 
@@ -93,6 +123,9 @@ apiversion = "3.0"
     `sfctl application create --app-name fabric:/Traefik --app-type TraefikType --app-version 1.0.4`
 
 12. To be able to ingress external requests via Træfik you'll need to open up and map the relevant ports on your public load balancer. For clusters on Azure, this will be your Azure Load Balancer. The default ports are; `tcp/80` (proxy) and `tcp/8080` (API) but these can be configured in `$REPO_ROOT\Traefik\ApplicationPackageRoot\TraefikPkg\Code\traefik.toml` and in `$REPO_ROOT\Traefik\Traefik\ApplicationPackageRoot\TraefikPkg\ServiceManifest.xml`.
+
+>**NOTE:** If you have applied the changes for Linux clusters in step 6, you can map Traefik's proxy
+>endpoint using a high port to a standard port (e.g. 80 or 443) on the Azure Load Balancer.
 
 13. Once the load balancer has been configured to route traffic on the required ports, you should be able to visit the Træfik dashboard at http[s]://[clusterfqdn]:8080 if you have it enabled.
 


### PR DESCRIPTION
This fixes issue #69 by providing detailed instructions how to update `ApplicationManifest.xml`, `ServiceManifest.xml`, and `traefik.toml` so the Traefic  application package can be deployed on a Linux cluster as well.