### PR TITLE
Added note to "Adding Service Labels" section

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -59,7 +59,7 @@ The Service Fabric service requires the UriScheme attrbute set in its Endpoint R
   </Resources>` 
   
 > **Note:**
-StatelessServiceTypes are fully supported, with rough support for StatefulServicesTypes right now. The discussion around support for StatefulServiceTypes is ongoing. See [Issue 45 to follow the progress](https://github.com/jjcollinge/traefik-on-service-fabric/issues/45).
+Stateless Services and Guest Executables are fully supported with experimental support for Stateful Services. The discussion around more complete support for Stateful Service is ongoing. See [Issue 45 to follow the progress](https://github.com/jjcollinge/traefik-on-service-fabric/issues/45).
 
 ## Dynamically updating Service labels
 Once you've deployed your service with some default labels, you may need to change the way Træfik is routing requests without redeploying. You can overwrite and add new labels to a named service using Service Fabric's Property Management API. Træfik will then pick up these new/updated labels and reconfigure itself.

--- a/Readme.MD
+++ b/Readme.MD
@@ -57,6 +57,9 @@ The Service Fabric service requires the UriScheme attrbute set in its Endpoint R
       <Endpoint Protocol="http" Name="ServiceEndpoint" Type="Input" Port="9001" UriScheme="http" />
     </Endpoints>
   </Resources>` 
+  
+> **Note:**
+StatelessServiceTypes are fully supported, with rough support for StatefulServicesTypes right now. The discussion around support for StatefulServiceTypes is ongoing. See [Issue 45 to follow the progress](https://github.com/jjcollinge/traefik-on-service-fabric/issues/45).
 
 ## Dynamically updating Service labels
 Once you've deployed your service with some default labels, you may need to change the way Træfik is routing requests without redeploying. You can overwrite and add new labels to a named service using Service Fabric's Property Management API. Træfik will then pick up these new/updated labels and reconfigure itself.


### PR DESCRIPTION
Hey, thanks for the all the work put into this project! It's really making our lives a lot easier.

I have one small suggestion for the docs, and it's that I believe support for Service Types should be clarified in the _Adding Service Labels_ section.  

In particular, perhaps it should be highlighted that only Stateless Service Types are fully supported right now, as I spent a decent amount of time wondering why I couldn't get a Frontend label registered for my Stateful Service, before coming across this open issue: https://github.com/containous/traefik-extra-service-fabric/issues/32.

Thanks,
Paul