### PR TITLE
Updated broken link in "available labels" section.

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -89,7 +89,7 @@ sfctl property put --name-id "GettingStartedApplication/WebService" --property-n
 > The command above is current as of sftcl v4.0.0.
 
 ### Available Labels
-The current list of available labels is documented [here](https://master--traefik-docs.netlify.com/configuration/backends/servicefabric/). This is subject to change as we expand our capabilities.
+The current list of available labels is documented [here](https://docs.traefik.io/configuration/backends/servicefabric/). This is subject to change as we expand our capabilities.
 
 ## Debugging 
 Both services will output logs to `stdout` and `stderr`. To enable these logs uncomment the `ConsoleRedirection` line in both `ServiceManifest.xml` files. 


### PR DESCRIPTION
Hi there,

I have updated the broken link in the "available labels" section.

The current link points at https://master--traefik-docs.netlify.com/configuration/backends/servicefabric/ which is not working at this time.

I've pointed it at the current docs, as I am unsure if there is a better working option right now.

Thanks,
Paul