### PR TITLE
Updating  watchdog's version

### DIFF
--- a/Docs/EnableWatchdog.MD
+++ b/Docs/EnableWatchdog.MD
@@ -41,4 +41,4 @@ Enable Application Insight Traefik Watchdog
       </ExeHost>
 ```
 
-3. *Optional* Review, add or adjust any arguments for full details on the watchdog see it's [repository here](https://github.com/lawrencegripper/traefik-appinsights-watchdog)
+3. *Optional* Review, add or adjust any arguments (i.e.: credentials to call Traefik's "/health" endpoint). For full details on the watchdog see it's [repository here](https://github.com/lawrencegripper/traefik-appinsights-watchdog)

--- a/Traefik/Scripts/Get-TraefikBinary.ps1
+++ b/Traefik/Scripts/Get-TraefikBinary.ps1
@@ -5,7 +5,7 @@
 
 param(
     [string]$version,
-    [string]$urlWatchdog = "https://github.com/lawrencegripper/traefik-appinsights-watchdog/releases/download/20180503100605-bc72588/traefik-appinsights-watchdog.exe"
+    [string]$urlWatchdog = "https://github.com/lawrencegripper/traefik-appinsights-watchdog/releases/download/20190114085656-a7e73a9/traefik-appinsights-watchdog.exe"
 )
 
 while (!($version)) {


### PR DESCRIPTION
Added a couple of optional parameters to watchdog for Traefik's credentials in case the APIs endpoint ("/health" included) is protected with basic auth. The change is released now.